### PR TITLE
updated for savon version 0.9.9

### DIFF
--- a/lib/savon/soap/request.rb
+++ b/lib/savon/soap/request.rb
@@ -4,23 +4,24 @@ module Savon
 
     private
 
-      def setup(request, soap)
-        request.url = soap.endpoint
+      def configure(http)
+        http.url = soap.endpoint
         if soap.has_parts? # do multipart stuff if soap has parts
           request_message = soap.request_message
-          # takes relevant http headers from the "Mail" message and makes them Net::HTTP compatible
-          request.headers["Content-Type"] ||= ContentType[soap.version]
+          # takes relevant http headers from the "Mail" message and makes
+          # them Net::HTTP compatible
           request_message.header.fields.each do |field|
-            request.headers[field.name] = field.to_s
+            http.headers[field.name] = field.to_s
           end
           #request.headers["Content-Type"] << %|; start="<savon_soap_xml_part>"|
           request_message.body.set_sort_order soap.parts_sort_order if soap.parts_sort_order && soap.parts_sort_order.any?
-          request.body = request_message.body.encoded
+          http.body = request_message.body.encoded
         else
-          request.headers["Content-Type"] ||= ContentType[soap.version]
-          request.body = soap.to_xml
+          http.body = soap.to_xml
         end
-        request
+        http.headers["Content-Type"] ||= ContentType[soap.version]
+        http.headers["Content-Length"] = http.body.bytesize.to_s
+        http
       end
 
     end


### PR DESCRIPTION
Hi Rubiii,

I'm successfully using savon-multipart to communicate with hermes2 (http://www.cecid.hku.hk/hermes.php). I had to do two changes though. The first is a real ugly hack to unwrap the soap header. The second is this one. I was using savon version 0.9.9 and I think the savon-multipart is for an older version. Please consider these changes.

Many thanks for savon, it really making me look good here on my job ;)

Mathijs
