### PR TITLE
Remove pry-debugger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,6 @@
 source 'https://rubygems.org'
 gemspec
 
-group :development do
-  gem 'pry'
-end
-
 platform :rbx do
   gem 'json'
   gem 'racc'

--- a/savon-multipart.gemspec
+++ b/savon-multipart.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mail", "2.5.3"
 
   s.add_development_dependency "rake"
+  s.add_development_dependency "pry"
   s.add_development_dependency "rspec"
   s.add_development_dependency "autotest"
   s.add_development_dependency "transpec"


### PR DESCRIPTION
Pry-debugger only works with Ruby 1.9 and depends on Readline (https://github.com/nixme/pry-debugger#caveats). I removed the dependency in the Gemfile and moved the development dependency on Pry to the gemspec
