### PR TITLE
Add ability to flatten MTOM XOP parts back into the main XML document.

### DIFF
--- a/lib/savon/multipart/response.rb
+++ b/lib/savon/multipart/response.rb
@@ -22,7 +22,12 @@ module Savon
       def xml
         if multipart?
           parse_body unless @has_parsed_body
-          @parts.first.body.to_s
+          if xop?
+            parse_xop unless @has_parsed_xop
+            @xop_body
+          else
+            @parts.first.body.to_s
+          end
         else
           super
         end
@@ -31,6 +36,15 @@ module Savon
       private
       def multipart?
         !(http.headers['content-type'] =~ /^multipart/im).nil?
+      end
+
+      def xop?
+        if multipart?
+          parse_body unless @has_parsed_body
+          !(@parts.first.header['content-type'].to_s =~ /^application\/xop\+xml/i).nil?
+        else
+          false
+        end
       end
 
       def boundary
@@ -44,6 +58,25 @@ module Savon
           :body => http.body
         ).body.split!(boundary).parts
         @has_parsed_body = true
+      end
+
+      def parse_xop
+        xml = @parts.first.body.to_s
+        parsed = Nokogiri.XML(xml)
+        xop_elements = parsed.xpath('//xop:Include', xop: "http://www.w3.org/2004/08/xop/include")
+        if xop_elements.count == 0
+          @xop_body = @parts.first.body.to_s
+          @has_parsed_xop = true
+          return
+        end
+        xop_elements.each do |xop_element|
+          href = xop_element.attributes['href'].to_s
+          cid = href[4..-1]
+          data = @parts.find { |p| p.header['content-id'].to_s == "<#{cid}>" }.body.to_s
+          xop_element.parent.content = Base64.encode64(data).chomp
+        end
+        @xop_body = parsed.to_s
+        @has_parsed_xop = true
       end
     end
   end

--- a/spec/fixtures/response/simple_xop.txt
+++ b/spec/fixtures/response/simple_xop.txt
@@ -1,0 +1,13 @@
+----==_mimepart_4d416ae62fd32_201a8043814c4724
+Content-ID: <http://tempuri.org/0>
+Content-Transfer-Encoding: 8bit
+Content-Type: application/xop+xml;charset=utf-8;type="text/xml"
+
+<?xml version="1.0" encoding="UTF-8"?><envelope ><header></header><body><BinaryData><xop:Include href="cid:http://tempuri.org/1/123456789" xmlns:xop="http://www.w3.org/2004/08/xop/include"/></BinaryData></body></envelope>
+----==_mimepart_4d416ae62fd32_201a8043814c4724
+Content-ID: <http://tempuri.org/1/123456789>
+Content-Transfer-Encoding: binary
+Content-Type: application/octet-stream
+
+BinaryDataGoesHere
+----==_mimepart_4d416ae62fd32_201a8043814c4724--

--- a/spec/savon/soap/response_spec.rb
+++ b/spec/savon/soap/response_spec.rb
@@ -53,6 +53,19 @@ describe Savon::Multipart::Response do
     end
   end
 
+  context "simple xop" do
+    let(:path) { File.expand_path('../../../fixtures/response/simple_xop.txt', __FILE__) }
+
+    it "returns a String from the #xml method" do
+      expect(response.xml.class).to eq(String)
+    end
+
+    it "returns a Hash from the #body method, include xop data" do
+      expect(response.body.class).to eq(Hash)
+      expect(response.body).to eq({:binary_data => Base64.encode64('BinaryDataGoesHere').chomp})
+    end
+  end
+
   describe "a multipart response with case sensitive headers" do
     let(:header) {{ "Content-Type" => 'MuLtIpArT/rElAtEd; boundary="--==_mimepart_4d416ae62fd32_201a8043814c4724"; charset=UTF-8; type="text/xml"' }}
     let(:path) { File.expand_path('../../../fixtures/response/simple_multipart.txt', __FILE__) }


### PR DESCRIPTION
MTOM with XOP allows binary data to be included alongside the main document using multipart, this change means savon-multipart will always flatten the data back into the original document (i.e. savon users no longer have to treat XOP documents any differently to normal soap requests).

Not sure if this project is looking for this kind of contribution, but looking at the various multipart issues that have been opened on savon it looks like XOP is a common reason to want multipart support.