### PR TITLE
Update mail dependency

### DIFF
--- a/savon-multipart.gemspec
+++ b/savon-multipart.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = s.name
 
   s.add_dependency "savon", "~> 2"
-  s.add_dependency "mail", "~> 2.5.4"
+  s.add_dependency "mail", "~> 2.6"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "pry"


### PR DESCRIPTION
* V 2.5.4 raises security advisory:
  Title: Mail Gem for Ruby vulnerable to SMTP Injection via recipient email addresses
  Solution: upgrade to >= 2.6.0
* others have implemented this in forks
* eg https://github.com/anjinfan/savon-multipart/commit/d8ee7bb724133a2819b3a25c5c3ce71e65d41f82