### PR TITLE
loosen mail version

### DIFF
--- a/savon-multipart.gemspec
+++ b/savon-multipart.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = s.name
 
   s.add_dependency "savon", "~> 2"
-  s.add_dependency "mail", "~> 2.5.4"
+  s.add_dependency "mail", ">= 2.5.4"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "pry"


### PR DESCRIPTION
Since mail v2.5.4 has security issues, can we at least loose the dependency?

see https://github.com/rubysec/ruby-advisory-db/blob/master/gems/mail/OSVDB-131677.yml