### PR TITLE
Scope CI push trigger to default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: Ruby
 
 on:
-  - push
-  - pull_request
+  push:
+    branches: [main]
+  pull_request:
 
 permissions:
   contents: read # checkout only, nothing else


### PR DESCRIPTION
Scopes the `push` trigger in `ci.yml` to `main` only. PR branches trigger via `pull_request` already, so this stops the test suite from running twice on every PR push. No other workflow changes.